### PR TITLE
added basic search functionality

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -129,6 +129,178 @@ impl Buffer {
         self.insert_char(line, col, '\n');
     }
 
+    /// Find pattern in a single line at or after start_col; returns (line_idx, col) if found.
+    fn find_in_line(
+        &self,
+        line_idx: usize,
+        start_col: usize,
+        pattern_chars: &[char],
+    ) -> Option<(usize, usize)> {
+        if pattern_chars.is_empty() {
+            return None;
+        }
+        let line_len = self.line_len(line_idx);
+        let line_chars: Vec<char> = self
+            .line(line_idx)
+            .map(|l| l.chars().take(line_len).collect())?;
+        let max_start = line_len.saturating_sub(pattern_chars.len());
+        for col in start_col..=max_start {
+            if col + pattern_chars.len() <= line_chars.len()
+                && line_chars[col..].starts_with(pattern_chars)
+            {
+                return Some((line_idx, col));
+            }
+        }
+        None
+    }
+
+    /// Find the next occurrence of pattern forward from (start_line, start_col).
+    /// Returns (line, col) of the first character of the match, or None if not found.
+    /// Search starts after the cursor on the current line (vim-style /).
+    pub fn find_forward(
+        &self,
+        start_line: usize,
+        start_col: usize,
+        pattern: &str,
+        wrap: bool,
+    ) -> Option<(usize, usize)> {
+        let pattern_chars: Vec<char> = pattern.chars().collect();
+        if pattern_chars.is_empty() {
+            return None;
+        }
+        let line_count = self.line_count();
+        if line_count == 0 {
+            return None;
+        }
+
+        // Pass 1: from (start_line, start_col+1) to end of buffer
+        if start_line < line_count {
+            if let Some((line, col)) =
+                self.find_in_line(start_line, start_col + 1, &pattern_chars)
+            {
+                return Some((line, col));
+            }
+        }
+        for line_idx in (start_line + 1)..line_count {
+            if let Some((line, col)) = self.find_in_line(line_idx, 0, &pattern_chars) {
+                return Some((line, col));
+            }
+        }
+
+        // Pass 2 (wrap): from (0, 0) to (start_line, start_col)
+        if wrap {
+            for line_idx in 0..start_line {
+                if let Some(m) = self.find_in_line(line_idx, 0, &pattern_chars) {
+                    return Some(m);
+                }
+            }
+            if start_line < line_count {
+                if let Some((line, col)) =
+                    self.find_in_line(start_line, 0, &pattern_chars)
+                {
+                    if col <= start_col {
+                        return Some((line, col));
+                    }
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Find the last occurrence of pattern before (start_line, start_col) (previous match).
+    pub fn find_backward(
+        &self,
+        start_line: usize,
+        start_col: usize,
+        pattern: &str,
+        wrap: bool,
+    ) -> Option<(usize, usize)> {
+        let pattern_chars: Vec<char> = pattern.chars().collect();
+        if pattern_chars.is_empty() {
+            return None;
+        }
+        let line_count = self.line_count();
+        if line_count == 0 {
+            return None;
+        }
+
+        // Pass 1: current line from start_col-1 down to 0, then lines start_line-1 down to 0
+        if start_line < line_count && start_col > 0 {
+            let line_len = self.line_len(start_line);
+            let line_chars: Vec<char> = self
+                .line(start_line)
+                .map(|l| l.chars().take(line_len).collect())?;
+            let max_start = line_len.saturating_sub(pattern_chars.len());
+            for col in (0..start_col.min(max_start + 1)).rev() {
+                if col + pattern_chars.len() <= line_chars.len()
+                    && line_chars[col..].starts_with(&pattern_chars[..])
+                {
+                    return Some((start_line, col));
+                }
+            }
+        }
+        for line_idx in (0..start_line).rev() {
+            if let Some((line, col)) =
+                self.find_in_line_backward(line_idx, self.line_len(line_idx), &pattern_chars)
+            {
+                return Some((line, col));
+            }
+        }
+
+        // Pass 2 (wrap): from end of buffer down to (start_line, start_col)
+        if wrap {
+            for line_idx in (start_line + 1)..line_count {
+                if let Some((line, col)) =
+                    self.find_in_line_backward(line_idx, self.line_len(line_idx), &pattern_chars)
+                {
+                    return Some((line, col));
+                }
+            }
+            if start_line < line_count {
+                let line_len = self.line_len(start_line);
+                let line_chars: Vec<char> = self
+                    .line(start_line)
+                    .map(|l| l.chars().take(line_len).collect())?;
+                let max_start = line_len.saturating_sub(pattern_chars.len());
+                for col in (start_col..=max_start).rev() {
+                    if col + pattern_chars.len() <= line_chars.len()
+                        && line_chars[col..].starts_with(&pattern_chars[..])
+                    {
+                        return Some((start_line, col));
+                    }
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Find last occurrence of pattern in line up to end_col; returns (line_idx, col).
+    fn find_in_line_backward(
+        &self,
+        line_idx: usize,
+        end_col: usize,
+        pattern_chars: &[char],
+    ) -> Option<(usize, usize)> {
+        if pattern_chars.is_empty() {
+            return None;
+        }
+        let line_len = self.line_len(line_idx);
+        let line_chars: Vec<char> = self
+            .line(line_idx)
+            .map(|l| l.chars().take(line_len).collect())?;
+        let max_start = (end_col).saturating_sub(pattern_chars.len()).min(line_len.saturating_sub(pattern_chars.len()));
+        for col in (0..=max_start).rev() {
+            if col + pattern_chars.len() <= line_chars.len()
+                && line_chars[col..].starts_with(pattern_chars)
+            {
+                return Some((line_idx, col));
+            }
+        }
+        None
+    }
+
     /// Get the filename (just the name, not the full path)
     pub fn filename(&self) -> Option<String> {
         self.file_path

--- a/src/input.rs
+++ b/src/input.rs
@@ -17,6 +17,7 @@ pub fn handle_key_event(editor: &mut Editor, key: KeyEvent) -> InputResult {
         Mode::Normal => handle_normal_mode(editor, key),
         Mode::Insert => handle_insert_mode(editor, key),
         Mode::Command => handle_command_mode(editor, key),
+        Mode::Search => handle_search_mode(editor, key),
     }
 }
 
@@ -100,6 +101,15 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) -> InputResult {
 
         // Enter command mode
         KeyCode::Char(':') => editor.enter_command_mode(),
+        KeyCode::Char('/') => editor.enter_search_mode(),
+
+        // Search repeat
+        KeyCode::Char('n') => {
+            editor.repeat_search_forward();
+        }
+        KeyCode::Char('N') => {
+            editor.repeat_search_backward();
+        }
 
         // Ctrl+C will set the mode to normal_mode 
         KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -149,6 +159,27 @@ fn handle_insert_mode(editor: &mut Editor, key: KeyEvent) -> InputResult {
         _ => {}
     }
 
+    InputResult::Continue
+}
+
+/// Handle key events in search mode (vim /)
+fn handle_search_mode(editor: &mut Editor, key: KeyEvent) -> InputResult {
+    match key.code {
+        KeyCode::Esc => return return_to_normal_mode(editor),
+        KeyCode::Enter => {
+            editor.search_forward();
+            editor.command_buffer.clear();
+            editor.enter_normal_mode();
+        }
+        KeyCode::Backspace => {
+            if editor.command_buffer.is_empty() {
+                return return_to_normal_mode(editor);
+            }
+            editor.command_buffer.pop();
+        }
+        KeyCode::Char(c) => editor.command_buffer.push(c),
+        _ => {}
+    }
     InputResult::Continue
 }
 

--- a/src/mode.rs
+++ b/src/mode.rs
@@ -7,6 +7,8 @@ pub enum Mode {
     Insert,
     /// Command mode - for entering commands (after pressing :)
     Command,
+    /// Search mode - for searching in buffer
+    Search,
 }
 
 impl Mode {
@@ -16,6 +18,7 @@ impl Mode {
             Mode::Normal => "NORMAL",
             Mode::Insert => "INSERT",
             Mode::Command => "COMMAND",
+            Mode::Search => "SEARCH",
         }
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -107,6 +107,7 @@ fn render_status_bar(frame: &mut Frame, editor: &Editor, area: Rect) {
         Mode::Normal => Style::default().bg(Color::Blue).fg(Color::White),
         Mode::Insert => Style::default().bg(Color::Green).fg(Color::Black),
         Mode::Command => Style::default().bg(Color::Yellow).fg(Color::Black),
+        Mode::Search => Style::default().bg(Color::Magenta).fg(Color::White),
     };
 
     let filename = editor
@@ -150,6 +151,7 @@ fn render_status_bar(frame: &mut Frame, editor: &Editor, area: Rect) {
 fn render_command_line(frame: &mut Frame, editor: &Editor, area: Rect) {
     let content = match editor.mode {
         Mode::Command => format!(":{}", editor.command_buffer),
+        Mode::Search => format!("/{}", editor.command_buffer),
         _ => editor
             .status_message
             .clone()
@@ -162,9 +164,10 @@ fn render_command_line(frame: &mut Frame, editor: &Editor, area: Rect) {
 
 /// Position the cursor in the frame
 fn position_cursor(frame: &mut Frame, editor: &Editor, text_area: Rect) {
-    // In command mode, cursor is in the command line
-    if editor.mode == Mode::Command {
-        let x = 1 + editor.command_buffer.len() as u16; // +1 for the ':'
+    // In command or search mode, cursor is in the command line
+    if editor.mode == Mode::Command || editor.mode == Mode::Search {
+        let prefix_len = 1; // ':' or '/'
+        let x = prefix_len + editor.command_buffer.len() as u16;
         let y = frame.area().height - 1; // Last line
         frame.set_cursor_position((x, y));
         return;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new text-scanning logic and cursor movement that could cause off-by-one/Unicode edge-case bugs, but it’s self-contained and doesn’t touch persistence or security-sensitive code.
> 
> **Overview**
> Adds **basic vim-style search** across the buffer: `/` enters a new `Mode::Search`, `Enter` runs a forward search (with wrap), and `n`/`N` repeat the last search forward/backward.
> 
> Implements new `Buffer` search helpers (`find_forward`, `find_backward` + per-line scanning) and wires UI/status updates to display the `/` prompt, show a SEARCH mode indicator, and place the cursor in the command line while searching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7fe1b5fa299f7a74f107519863c3a951b6022a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->